### PR TITLE
feat(app): added app version property and log field to request logger

### DIFF
--- a/options.go
+++ b/options.go
@@ -9,9 +9,10 @@ import (
 )
 
 const (
-	defaultEnv  = "development"
-	defaultName = "FlowApp"
-	defaultAddr = "0.0.0.0:5000"
+	defaultEnv     = "development"
+	defaultName    = "FlowApp"
+	defaultAddr    = "0.0.0.0:5000"
+	defaultVersion = "v0.0.0"
 
 	defaultLogLevel = "debug"
 
@@ -47,9 +48,10 @@ const (
 
 // Options holds flow configuration options
 type Options struct {
-	Env  string
-	Name string
-	Addr string
+	Env     string
+	Name    string
+	Addr    string
+	Version string
 
 	LogLevel string
 
@@ -96,6 +98,7 @@ func NewOptions() Options {
 	opts := Options{
 		Env:                    defaultEnv,
 		Name:                   defaultName,
+		Version:                defaultVersion,
 		Addr:                   defaultAddr,
 		LogLevel:               defaultLogLevel,
 		RedirectTrailingSlash:  defaultRedirectTrailingSlash,

--- a/request_logger.go
+++ b/request_logger.go
@@ -40,13 +40,14 @@ func RequestLogger() HandlerFunc {
 		c.Next()
 
 		c.LogFields(log.Fields{
-			"status":     c.Response.Status(),
-			"method":     c.Request.Method,
-			"path":       c.Request.URL.String(),
-			"client_ip":  c.ClientIP(),
-			"duration":   time.Since(start).String(),
-			"size":       c.Response.Size(),
-			"human_size": byteCountDecimal(int64(c.Response.Size())),
+			"app-version": c.app.Version,
+			"status":      c.Response.Status(),
+			"method":      c.Request.Method,
+			"path":        c.Request.URL.String(),
+			"client_ip":   c.ClientIP(),
+			"duration":    time.Since(start).String(),
+			"size":        c.Response.Size(),
+			"human_size":  byteCountDecimal(int64(c.Response.Size())),
 		})
 		c.Logger().Info("request-logger")
 	}


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation

**What is the current behaviour? (You can also link to an open issue here)**
currently there is no way to know which application version is running on top of flow


**What is the new behaviour (if this is a feature change)?**
Version property is added to App Options with default value "v0.0.0"
Request logger now logs app-version field too


**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**Please check if the PR fulfils these requirements**

- [x] You’ve rebased your work on the current state of the master tree
- [x] Your changes follow to the coding standards
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Your code is documented

**Other information**: